### PR TITLE
fixed a broken database link

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -197,7 +197,7 @@ async fn update_database(path: &str) -> Result<()> {
         "Downloading...".bright_yellow()
     );
 
-    let url = "https://raw.githubusercontent.com/sherlock-project/sherlock/master/sherlock/resources/data.json";
+    let url = "https://raw.githubusercontent.com/sherlock-project/sherlock/master/sherlock_project/resources/data.json";
 
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(60))


### PR DESCRIPTION
fixed the `Error: Failed to download database: HTTP 404 Not Found` error message. (https://github.com/krishpranav/maigret/issues/5)

This error message happened because the Sherlock project changed the directory name from `sherlock` to `sherlock_project`.